### PR TITLE
manage multiple ssh config files too

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Installation
 
 Clone this repo or download the setgit bash script to a folder in your path.
 
-Copy your current gitconfig to gitconfig-me.  
+Copy your current ~/.gitconfig to ~/.gitconfig-me
+Copy your current ~/.ssh/config to ~/.ssh/config-me
 
-Then create your different .gitconfigs appending the name with -sourcename. For example .gitconfig-work
+Then create your different git and ssh config files appending the name with -sourcename.
+For example ~/.gitconfig-work and ~/.ssh/config-work
 
 
 Running
@@ -20,7 +22,8 @@ Running
 From the command line run:
 $ setgit sourcename
 
-The contents of .gitconfig-sourcename will overwrite the .gitconfig contents.
+The contents of ~/.gitconfig-sourcename will overwrite the ~/.gitconfig contents.
+The contents of ~/.ssh/config-sourcename will overwrite the ~/.ssh/config contents.
 
 When you want to switchback to your original config run:
 $ setgit me

--- a/setgit
+++ b/setgit
@@ -17,17 +17,28 @@ import sys, os, shutil, argparse
 
 # Main Program
 def main():
+	# Define working_git_config and working_ssh_config
+	working_git_config=(os.environ['HOME'] + '/.gitconfig')
+	working_ssh_config=(os.environ['HOME'] + '/.ssh/config')
+
 	# Create Parser that will read command line input
 	parser = argparse.ArgumentParser(description="create .gitconfig from a source file .gitconfig-source")
 	parser.add_argument('source',
                     help='the source identifier')
 	args = parser.parse_args()
 
+	# If new_git_config and new_ssh_config exist, copy them to working_git_config and working_ssh_config
 	if args.source:
-		if os.path.isfile(os.environ['HOME'] + '/.gitconfig-' + args.source ):
-			shutil.copyfile(os.environ['HOME'] + '/.gitconfig-' + args.source, os.environ['HOME'] + '/.gitconfig' )
+		new_git_config=(os.environ['HOME'] + '/.gitconfig-' + args.source)
+		if os.path.isfile(new_git_config):
+			shutil.copyfile(new_git_config, working_git_config)
 		else:
-			print "I could not find a source file " + os.environ['HOME'] + "/.gitconfig-" + args.source
+			print "I could not find a source file " + new_git_config
+		new_ssh_config=(os.environ['HOME'] + '/.ssh/config-' + args.source)
+		if os.path.isfile(new_ssh_config):
+			shutil.copyfile(new_ssh_config, working_ssh_config)
+		else:
+			print "I could not find a source file " + new_ssh_config
 
 # Ok, so we're doing this...
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds the capability to manage multiple SSH config files too, which is necessary if your employer's GitHub organization enforces SAML Single-Sign-On, for which [GitHub requires an authorized SSH key](https://help.github.com/articles/authorizing-an-ssh-key-for-use-with-a-saml-single-sign-on-organization/).

Rather than authorize a personal SSH key for your employer's GitHub organization, you can seamlessly switch between multiple SSH configs which have different IdentityFile values for Host github.com:

For example:

```
Host github.com
 	User git
 	IdentityFile ~/.ssh/personal_rsa
```
vs

```
Host github.com
 	User git
 	IdentityFile ~/.ssh/work_rsa
```